### PR TITLE
Use env var for API key

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,7 +12,7 @@ Define all sensitive configuration in environment variables, not in code. Exampl
 ```dotenv
 # Core
 APP_ENV=development               # development | staging | production
-API_KEY=your_global_api_key
+ZANALYTICS_API_KEY=your_global_api_key
 SECRET_KEY=your_jwt_signing_key
 
 # Database

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ pip install -r requirements.txt
 
 # Copy example environment variables
 cp .env.example .env
-# Edit .env to include your OPENAI_API_KEY and other settings
+# Edit .env to include your OPENAI_API_KEY, ZANALYTICS_API_KEY, and other settings
 
 # (Optional) Start the FastAPI server for local development
 uvicorn main:app --reload --env-file .env
@@ -39,9 +39,10 @@ vercel --prod
 ```
 
 ## Configure Environment Variables
-Rename and edit your `.env` file to include the following keys:
+- Rename and edit your `.env` file to include the following keys:
 
 - `OPENAI_API_KEY` — Your OpenAI API key.
+- `ZANALYTICS_API_KEY` — Key required by the FastAPI server.
 - `FASTAPI_HOST` — Hostname or IP for FastAPI (default: `0.0.0.0`).
 - `FASTAPI_PORT` — Port number for FastAPI (default: `8000`).
 - `RAILWAY_API_URL` — (Optional) Railway deployment URL.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Use the sidebar to navigate, or jump directly to the [GitHub repo](https://githu
 
 ## Configuration
 This framework uses [Pydantic Settings](https://pydantic-docs.helpmanual.io/usage/settings/) and environment variables to centralize runtime configuration. Copy `.env.example` to `.env` and define:
-- `API_KEY`: Your global service authentication key
+- `ZANALYTICS_API_KEY`: Your global service authentication key
 - `ENVIRONMENT`: `development` or `production`
 - `DATABASE_URL`: Connection string for your persistence layer
 - `LOG_LEVEL`: `DEBUG`, `INFO`, `WARN`, or `ERROR`

--- a/main.py
+++ b/main.py
@@ -3,12 +3,20 @@ from fastapi import FastAPI, Depends, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security.api_key import APIKeyHeader
 from core.orchestrator import handle_user_input
+import os
 
 API_KEY_NAME = "X-API-Key"
 api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
 
+ZANALYTICS_API_KEY = os.environ.get("ZANALYTICS_API_KEY")
+
+
 async def verify_api_key(api_key: str = Depends(api_key_header)):
-    if api_key != "YOUR_SECURE_API_KEY":
+    if ZANALYTICS_API_KEY is None:
+        raise RuntimeError(
+            "ZANALYTICS_API_KEY environment variable must be set before running the server"
+        )
+    if api_key != ZANALYTICS_API_KEY:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or missing API Key",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 os.environ["ZANALYTICS_TEST_MODE"] = "1"
+os.environ["ZANALYTICS_API_KEY"] = "test_secret"
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 from main import app
@@ -15,7 +16,7 @@ def test_log_endpoint_success():
     response = client.post(
         "/log",
         json={"message": "hello"},
-        headers={"X-API-Key": "YOUR_SECURE_API_KEY"},
+        headers={"X-API-Key": "test_secret"},
     )
     assert response.status_code == 200
     assert isinstance(response.json(), dict)

--- a/tutorials/quickstart.md
+++ b/tutorials/quickstart.md
@@ -43,7 +43,7 @@ DATABASE_URL=sqlite:///./data.db  # or postgres://... for scale dev
 AWS_REGION=us-east-1              # for AWS Lambda / DynamoDB
 
 # Security
-API_KEY=<your_api_key>            # required for all /invoke requests
+ZANALYTICS_API_KEY=<your_api_key> # required for all /invoke requests
 
 # Deployment
 RAILWAY_PROJECT=<railway_project_id>
@@ -65,7 +65,7 @@ Test the generic `/invoke` endpoint:
 ```bash
 curl -X POST http://localhost:${FASTAPI_PORT}/invoke \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: ${API_KEY}" \
+  -H "X-API-Key: ${ZANALYTICS_API_KEY}" \
   -d '{
     "user_id": "demo_user",
     "business_type": "example",


### PR DESCRIPTION
## Summary
- rely on `ZANALYTICS_API_KEY` to secure the API
- document new required environment variable
- update example usage to reference `ZANALYTICS_API_KEY`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: the following arguments are required: --file)*

------
https://chatgpt.com/codex/tasks/task_b_685ac8a3c07c832e934af76e1fc0f0ab