### PR TITLE
Add ZanFlow enrichment engine

### DIFF
--- a/copilot_orchestrator.py
+++ b/copilot_orchestrator.py
@@ -91,6 +91,8 @@ except ImportError: log_info("WARN: core/confluence_engine.py not found.", "WARN
 # --- NEW: Import Liquidity Sweep Detector ---
 try: from core.liquidity_sweep_detector import tag_liquidity_sweeps
 except ImportError: log_info("WARN: core/liquidity_sweep_detector.py not found.", "WARN"); tag_liquidity_sweeps = None
+try: from core.zanflow_enrichment_engine_v3 import apply_zanflow_enrichment
+except ImportError: log_info("WARN: core/zanflow_enrichment_engine_v3.py not found.", "WARN"); apply_zanflow_enrichment = None
 
 
 # --- Chart Generation Function (ENHANCED to include Wyckoff & Sweeps) ---
@@ -388,6 +390,8 @@ def handle_price_check(pair: str, timestamp_str: str, tf: str = 'm15', strategy_
                 if tag_mentfx_ici: df_temp = tag_mentfx_ici(df_temp, tf=tf_str_for_tagging)
                 # Apply Accumulation/Distribution Tags
                 if tag_accumulation: df_temp = tag_accumulation(df_temp)
+                # Apply ZanFlow Enrichment
+                if apply_zanflow_enrichment: df_temp = apply_zanflow_enrichment(df_temp, tf=tf_str_for_tagging)
                 # Wyckoff tagging is now done separately below
             except Exception as enrich_err: log_info(f"Error during enrichment for TF {tf_key}: {enrich_err}", "ERROR"); traceback.print_exc()
             enriched_tf_data[tf_key] = df_temp

--- a/core/zanflow_enrichment_engine_v3.py
+++ b/core/zanflow_enrichment_engine_v3.py
@@ -1,0 +1,50 @@
+# zanflow_enrichment_engine_v3.py
+# Author: ZANZIBAR LLM Assistant
+# Date: 2025-07-17
+# Version: 3.0.0
+# Description:
+#   Placeholder ZanFlow enrichment engine adding simple signal columns.
+
+import pandas as pd
+from typing import Dict, Optional
+
+
+def apply_zanflow_enrichment(df: pd.DataFrame, tf: str = "1min", config: Optional[Dict] = None) -> pd.DataFrame:
+    """Apply ZanFlow-specific enrichment to a DataFrame.
+
+    Args:
+        df: OHLCV DataFrame.
+        tf: Timeframe string.
+        config: Optional configuration dictionary.
+
+    Returns:
+        DataFrame enriched with a 'zanflow_signal' column.
+    """
+    df = df.copy()
+    if df.empty or not {"Open", "Close"}.issubset(df.columns):
+        return df
+
+    signals = []
+    for o, c in zip(df["Open"], df["Close"]):
+        if c > o:
+            signals.append("bullish")
+        elif c < o:
+            signals.append("bearish")
+        else:
+            signals.append("neutral")
+    df["zanflow_signal"] = signals
+    return df
+
+
+if __name__ == "__main__":
+    print("--- Testing ZanFlow Enrichment Engine v3 ---")
+    sample = {
+        "Open": [1, 2, 3],
+        "High": [2, 3, 4],
+        "Low": [0.5, 1.5, 2.5],
+        "Close": [1.5, 2.5, 2.8],
+        "Volume": [100, 110, 120],
+    }
+    df_sample = pd.DataFrame(sample)
+    enriched = apply_zanflow_enrichment(df_sample)
+    print(enriched)

--- a/marker_enrichment_engine.py
+++ b/marker_enrichment_engine.py
@@ -88,6 +88,14 @@ except ImportError:
     def tag_smc_zones(df, **kwargs): df[['bos', 'choch', 'fvg_zone']] = 'N/A (SMC Engine Missing)'; return df # Dummy
     SMC_ENGINE_LOADED = False
 
+try:
+    from zanflow_enrichment_engine_v3 import apply_zanflow_enrichment
+    ZANFLOW_ENGINE_LOADED = True
+except ImportError:
+    print("[WARN][MarkerEnrichment] zanflow_enrichment_engine_v3.py not found or failed to import 'apply_zanflow_enrichment'.")
+    def apply_zanflow_enrichment(df, **kwargs): return df  # Dummy passthrough
+    ZANFLOW_ENGINE_LOADED = False
+
 
 # --- Main Enrichment Function ---
 
@@ -147,6 +155,8 @@ def add_all_indicators(df: pd.DataFrame, timeframe: str, config: Optional[Dict] 
             df_enriched = tag_wyckoff_phases(df_enriched, timeframe=timeframe, config=config.get('wyckoff_config'))
         if MENTFX_ENGINE_LOADED:
             df_enriched = tag_mentfx_ici(df_enriched, timeframe=timeframe, config=config.get('mentfx_config'))
+        if ZANFLOW_ENGINE_LOADED:
+            df_enriched = apply_zanflow_enrichment(df_enriched, tf=timeframe, config=config.get('zanflow_config'))
 
         print(f"[INFO][MarkerEnrichment] Successfully completed enrichment for timeframe: {timeframe}.")
 


### PR DESCRIPTION
## Summary
- add placeholder ZanFlow enrichment engine in `core/`
- import and invoke the new enrichment engine from `marker_enrichment_engine` and `copilot_orchestrator`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ncos')*

------
https://chatgpt.com/codex/tasks/task_b_685d691e441c832ebd0ead347cd7cd99