### PR TITLE
Replace prints with logger in ZanFlow enrichment module

### DIFF
--- a/core/zanflow_enrichment_engine_v3.py
+++ b/core/zanflow_enrichment_engine_v3.py
@@ -5,8 +5,12 @@
 # Description:
 #   Placeholder ZanFlow enrichment engine adding simple signal columns.
 
+import logging
 import pandas as pd
 from typing import Dict, Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 def apply_zanflow_enrichment(df: pd.DataFrame, tf: str = "1min", config: Optional[Dict] = None) -> pd.DataFrame:
@@ -37,7 +41,7 @@ def apply_zanflow_enrichment(df: pd.DataFrame, tf: str = "1min", config: Optiona
 
 
 if __name__ == "__main__":
-    print("--- Testing ZanFlow Enrichment Engine v3 ---")
+    logger.info("--- Testing ZanFlow Enrichment Engine v3 ---")
     sample = {
         "Open": [1, 2, 3],
         "High": [2, 3, 4],
@@ -47,4 +51,4 @@ if __name__ == "__main__":
     }
     df_sample = pd.DataFrame(sample)
     enriched = apply_zanflow_enrichment(df_sample)
-    print(enriched)
+    logger.info("%s", enriched)


### PR DESCRIPTION
## Summary
- use project logger in `zanflow_enrichment_engine_v3.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_b_685d6b937d60832ea578674f8561e2df