### PR TITLE
Update requirements and document testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,18 @@ python run_full_stack.py --api-port 8000 --dash-port 8501
 
 The application populates the cache as data is requested.
 
+## Running Tests
+
+Install dependencies and run the unit tests from the project root:
+
+```bash
+pip install -r requirements.txt
+pytest -sv
+```
+
+`pytest` automatically enables `ZANALYTICS_TEST_MODE` via `tests/conftest.py`.
+Some integration tests are skipped unless a live API server is running.
+
 ## License
 
 This project is distributed under the terms of the [ZANALYTICS EULA](LICENSE_EULA.md).

--- a/_connector/requirements (2).txt
+++ b/_connector/requirements (2).txt
@@ -29,3 +29,5 @@ aiofiles>=23.0.0
 # Development and utilities
 tqdm>=4.66.0
 pyyaml>=6.0.1
+loguru>=0.7.0
+jinja2>=3.1.0

--- a/requirements (2).txt
+++ b/requirements (2).txt
@@ -29,3 +29,5 @@ aiofiles>=23.0.0
 # Development and utilities
 tqdm>=4.66.0
 pyyaml>=6.0.1
+loguru>=0.7.0
+jinja2>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,7 @@ jupyterlab_widgets==3.0.15
 kiwisolver==1.4.8
 llvmlite==0.44.0
 loguru==0.7.3
+jinja2==3.1.6
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 matplotlib==3.10.3


### PR DESCRIPTION
## Summary
- ensure loguru and jinja2 are included in the consolidated requirements
- explain how to run the test suite via pytest

## Testing
- `pip install -q -r requirements.txt` *(fails: No matching distribution found for MetaTrader5==5.0.45)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6869b0295b90832eac61207c5e732d8e